### PR TITLE
Test against Node 8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,14 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 env:
   - TEST_SUITE=unittests
-  - TEST_SUITE=browsers
-  - TEST_SUITE=demo
 matrix:
-  exclude:
-    - node_js: "4"
+  include:
+    - node_js: "6"
       env: TEST_SUITE=browsers
-    - node_js: "4"
+    - node_js: "6"
       env: TEST_SUITE=demo
 
 before_script:


### PR DESCRIPTION
As Node 8 is out and [scheduled to become the next LTS release](https://github.com/nodejs/LTS#lts-schedule1), it's logical to test against it.